### PR TITLE
chore(deps): bump sqlalchemy from 2.0.29 to 2.0.44

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.29.0
-sqlalchemy==2.0.29
+sqlalchemy==2.0.44
 asyncmy==0.2.9
 aiosqlite==0.21.0
 alembic==1.13.1
@@ -18,3 +18,4 @@ cryptography>=41.0.0
 libsql-client==0.3.1
 ollama==0.6.0
 langchain-text-splitters==0.3.11
+


### PR DESCRIPTION
解决python3.13与2.0.29版本冲突的问题