### PR TITLE
Add missing dependency: greenlet

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,4 +18,4 @@ cryptography>=41.0.0
 libsql-client==0.3.1
 ollama==0.6.0
 langchain-text-splitters==0.3.11
-
+greenlet==3.2.4


### PR DESCRIPTION
When running dev and backend service started, the backend report the trace stack which greenlet is not founded. We should add the missing dependency: greenlet, and the newest version is 3.2.4